### PR TITLE
Use proper PHP version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "php": "^7.0"
+        "php": ">=7.0"
     },
     "require-dev": {
         "jakub-onderka/php-parallel-lint": "0.9.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a7339e0ee7b61464a9e7369abdc46ac6",
+    "content-hash": "57b399eda59f19ef0c17541fcb223392",
     "packages": [],
     "packages-dev": [
         {
@@ -2266,7 +2266,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.0"
+        "php": ">=7.0"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
When using PHP `^7.0` as package requirement, the package will be failed to install on PHP 7.1 or higher, since Composer would always throw `Package x at version y has a PHP requirement incompatible with your PHP version`