### PR TITLE
Use Composer from Docker Image

### DIFF
--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -2,10 +2,9 @@ FROM php:8.0-cli-alpine
 
 ENV COMPOSER_CACHE_DIR /tmp
 
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-    && php composer-setup.php --install-dir /usr/bin --filename composer \
-    && php -r "unlink('composer-setup.php');" \
-    && find /usr/src -type f -name 'php.tar*' -delete \
+COPY --from=composer:2.0 /usr/bin/composer /usr/bin/composer
+
+RUN find /usr/src -type f -name 'php.tar*' -delete \
     && apk add unzip
 
 VOLUME /app


### PR DESCRIPTION
This PR updates `Dockerfile` to install Composer from Docker Image instead of directly download.