### PR TITLE
Reference Laminas

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ with other libraries or frameworks easier. If you want to add more items in this
 list, please, open an issue or create a pull request.
 
 * [Illuminate Romans](https://github.com/wandersonwhcr/illuminate-romans): Laravel Illuminate Romans Integration
-* [Zend Romans](https://github.com/wandersonwhcr/zend-romans): Zend Framework Romans Integration
+* [Laminas Romans](https://github.com/wandersonwhcr/laminas-romans): Laminas Project Romans Integration
+* ~~[Zend Romans](https://github.com/wandersonwhcr/zend-romans): Zend Framework Romans Integration~~ **DEPRECATED**
 
 ## Advanced Usage
 


### PR DESCRIPTION
This PR marks Zend Framework Romans as deprecated and adds Laminas Romans.