### PR TITLE
Update PHP release candidate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,9 @@ jobs:
         php_version:
           - "7.4"
           - "8.0"
-          - "8.1.0RC1"
+          - "8.1.0RC2"
         include:
-          - php_version: "8.1.0RC1"
+          - php_version: "8.1.0RC2"
             experimental: true
             composer_platform_php: "8.0"
     steps:

--- a/.github/workflows/updated.yml
+++ b/.github/workflows/updated.yml
@@ -31,9 +31,9 @@ jobs:
         php_version:
           - "7.4"
           - "8.0"
-          - "8.1.0RC1"
+          - "8.1.0RC2"
         include:
-          - php_version: "8.1.0RC1"
+          - php_version: "8.1.0RC2"
             experimental: true
             composer_platform_php: "8.0"
     steps:


### PR DESCRIPTION
This PR updates PHP release candidate to `8.1.0RC2`.