### PR TITLE
Upgrade PHP 8.1 to release candidate 6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,9 @@ jobs:
         php_version:
           - "7.4"
           - "8.0"
-          - "8.1.0RC5"
+          - "8.1.0RC6"
         include:
-          - php_version: "8.1.0RC5"
+          - php_version: "8.1.0RC6"
             experimental: true
             composer_platform_php: "8.0"
     steps:

--- a/.github/workflows/updated.yml
+++ b/.github/workflows/updated.yml
@@ -31,9 +31,9 @@ jobs:
         php_version:
           - "7.4"
           - "8.0"
-          - "8.1.0RC5"
+          - "8.1.0RC6"
         include:
-          - php_version: "8.1.0RC5"
+          - php_version: "8.1.0RC6"
             experimental: true
             composer_platform_php: "8.0"
     steps:


### PR DESCRIPTION
This PR bumps PHP 8.1 to the latest release candidate.