### PR TITLE
Avoid calculate valuesWithModifiers mutliple time

### DIFF
--- a/src/Grammar/Grammar.php
+++ b/src/Grammar/Grammar.php
@@ -19,9 +19,9 @@ class Grammar
     const T_M = 'M';
 
     /**
-     * @var array<int,string[]>
+     * @var array<int,string[]>|null
      */
-    private array $valuesWithModifiers;
+    private ?array $valuesWithModifiers = null;
 
     /**
      * Get Tokens

--- a/src/Grammar/Grammar.php
+++ b/src/Grammar/Grammar.php
@@ -19,6 +19,11 @@ class Grammar
     const T_M = 'M';
 
     /**
+     * @var array<int,string[]>
+     */
+    private array $valuesWithModifiers;
+
+    /**
      * Get Tokens
      *
      * @return array<string,int> Tokens Available
@@ -80,12 +85,18 @@ class Grammar
      */
     public function getValuesWithModifiers(): array
     {
+        if (isset($this->valuesWithModifiers)) {
+            return $this->valuesWithModifiers;
+        }
+
         $values = array_map(fn($value) => [$value], array_flip($this->getValues()));
 
         $valuesWithModifiers = $values + $this->getModifiers(); // merge and keep keys (append)
 
         ksort($valuesWithModifiers);
 
-        return $valuesWithModifiers;
+        $this->valuesWithModifiers = $valuesWithModifiers;
+
+        return $this->valuesWithModifiers;
     }
 }

--- a/test/Grammar/GrammarTest.php
+++ b/test/Grammar/GrammarTest.php
@@ -121,4 +121,17 @@ class GrammarTest extends TestCase
         $grammar->getValuesWithModifiers();
         $grammar->getValuesWithModifiers();
     }
+
+    /**
+     * Test Values with Modifiers Initialization
+     */
+    public function testValuesWithModifiersInitialization(): void
+    {
+        $reflection = new ReflectionClass(Grammar::class);
+        $property   = $reflection->getProperty('valuesWithModifiers');
+
+        $property->setAccessible(true);
+
+        $this->assertNull($property->getValue($this->grammar));
+    }
 }

--- a/test/Grammar/GrammarTest.php
+++ b/test/Grammar/GrammarTest.php
@@ -102,4 +102,23 @@ class GrammarTest extends TestCase
 
         $this->assertSame($valuesWithModifiers, $this->grammar->getValuesWithModifiers());
     }
+
+    /**
+     * Test Values with Modifiers Calculate Once
+     */
+    public function testValuesWithModifiersCalculateOnce(): void
+    {
+        $grammar = $this->getMockBuilder(Grammar::class)
+            ->onlyMethods(['getValues', 'getModifiers'])
+            ->getMock();
+
+        $grammar->expects($this->once())
+            ->method('getValues');
+
+        $grammar->expects($this->once())
+            ->method('getModifiers');
+
+        $grammar->getValuesWithModifiers();
+        $grammar->getValuesWithModifiers();
+    }
 }


### PR DESCRIPTION
This PR changes Grammar to avoid calculate `valuesWithModifiers` multiple times and optimize execution.